### PR TITLE
Handle case when ajax response has no "content-type" header

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -56,7 +56,7 @@ function ajax(options) {
 
     request.onload = function() {
 
-        var contentType = request.getResponseHeader('content-type');
+        var contentType = request.status === 204 ? '' : request.getResponseHeader('content-type');
         var responseText = request.responseText;
 
         if (request.status >= 200 && request.status < 400) {

--- a/test/ajax.js
+++ b/test/ajax.js
@@ -30,6 +30,10 @@ describe('Ajax', function() {
                 return [200, {'Content-Type': 'application/html'}, request.requestBody];
             });
 
+            this.post('/post-no-content-test', function(request) {
+                return [204, {}, ''];
+            });
+
         });
 
     });
@@ -73,6 +77,15 @@ describe('Ajax', function() {
 
         $.post('/post-test', {foo: 'bar'}).then(function(data) {
             assert.equal(data, 'foo=bar');
+            done();
+        });
+
+    });
+
+    it('"post" can send data and recieve a response without a "Content-Type" header', function(done) {
+
+        $.post('/post-no-content-test', {foo: 'bar'}, function(data) {
+            assert.equal(data, '');
             done();
         });
 


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc7231#section-3.1.1.5

Also:
- https://stackoverflow.com/questions/21029351/what-content-type-should-a-204-no-response-use
- https://stackoverflow.com/questions/29784398/should-content-type-header-be-present-when-the-message-body-is-empty